### PR TITLE
Only add popup if rect contains markers

### DIFF
--- a/dist/Leaflet.BlurredLocationDisplay.js
+++ b/dist/Leaflet.BlurredLocationDisplay.js
@@ -455,15 +455,15 @@ module.exports = function changeRectangleColor(options){
   function generatePopupContentsFromMarkers(markers) {
     let popupContents = "<p><b>People within this region:</b></p>";
     popupContents += "<ul>";
-//    if (marker[0].hasOwnProperty('url') && marker[0].hasOwnProperty('url')) {
+    if (markers[0].hasOwnProperty('url') && markers[0].hasOwnProperty('url')) {
       markers.forEach(function(marker) {
         if (marker.hasOwnProperty('url') && marker.hasOwnProperty('url')) {
           popupContents += "<li><a href='" + marker.url + "'>@" + marker.title + "</a></li>";
         }
       });
-//    } else {
-//      popupContents += "<p>" + markers.length + " people</p>";
-//    }
+    } else {
+      popupContents += "<p>" + markers.length + " people</p>";
+    }
     popupContents += "</ul>";
     popupContents += "<p>These people have blurred their location. Learn about <a href='https://publiclab.org/location-privacy'>location privacy here</a>.</p>";
     return popupContents;
@@ -483,8 +483,8 @@ module.exports = function changeRectangleColor(options){
       let markers = calculateMarkersInsideRect(bounds) ; 
       let color = getColorCode(markers.length) ;
       let r = L.rectangle(bounds, {color: color , weight: 1})
-        .bindPopup(generatePopupContentsFromMarkers(markers))
         .addTo(map);
+      if (markers.length > 0) r.bindPopup(generatePopupContentsFromMarkers(markers))
       rectangles[rectangles.length] = r ; 
       
       current_lng = current_lng - diff ; 
@@ -506,8 +506,8 @@ module.exports = function changeRectangleColor(options){
       let color = getColorCode(markers.length) ;
 
       let r = L.rectangle(bounds, {color: color , weight: 1})
-        .bindPopup(generatePopupContentsFromMarkers(markers))
         .addTo(map);
+      if (markers.length > 0) r.bindPopup(generatePopupContentsFromMarkers(markers))
       rectangles[rectangles.length] = r ; 
       
       current_lng = current_lng + diff ; 

--- a/src/ui/gridCenterRectangle.js
+++ b/src/ui/gridCenterRectangle.js
@@ -75,7 +75,7 @@ module.exports = function changeRectangleColor(options){
   function generatePopupContentsFromMarkers(markers) {
     let popupContents = "<p><b>People within this region:</b></p>";
     popupContents += "<ul>";
-    if (marker[0].hasOwnProperty('url') && marker[0].hasOwnProperty('url')) {
+    if (markers[0].hasOwnProperty('url') && markers[0].hasOwnProperty('url')) {
       markers.forEach(function(marker) {
         if (marker.hasOwnProperty('url') && marker.hasOwnProperty('url')) {
           popupContents += "<li><a href='" + marker.url + "'>@" + marker.title + "</a></li>";

--- a/src/ui/gridCenterRectangle.js
+++ b/src/ui/gridCenterRectangle.js
@@ -103,8 +103,8 @@ module.exports = function changeRectangleColor(options){
       let markers = calculateMarkersInsideRect(bounds) ; 
       let color = getColorCode(markers.length) ;
       let r = L.rectangle(bounds, {color: color , weight: 1})
-        .bindPopup(generatePopupContentsFromMarkers(markers))
         .addTo(map);
+      if (markers.length > 0) r.bindPopup(generatePopupContentsFromMarkers(markers))
       rectangles[rectangles.length] = r ; 
       
       current_lng = current_lng - diff ; 
@@ -126,8 +126,8 @@ module.exports = function changeRectangleColor(options){
       let color = getColorCode(markers.length) ;
 
       let r = L.rectangle(bounds, {color: color , weight: 1})
-        .bindPopup(generatePopupContentsFromMarkers(markers))
         .addTo(map);
+      if (markers.length > 0) r.bindPopup(generatePopupContentsFromMarkers(markers))
       rectangles[rectangles.length] = r ; 
       
       current_lng = current_lng + diff ; 


### PR DESCRIPTION
We may need to check if we need a popup to exist upon modifying the markers on the map with subsequent data loads; should we instead make an empty popup? Or, does it later detect that no popup exists and creates one, or does it flush all popups and regenerate them on new data being loaded?